### PR TITLE
Prevent adding identical remark and removing already empty remark

### DIFF
--- a/src/main/java/nurseybook/logic/commands/RemarkCommand.java
+++ b/src/main/java/nurseybook/logic/commands/RemarkCommand.java
@@ -29,7 +29,9 @@ public class RemarkCommand extends Command {
             + PREFIX_REMARK + "Likes to swim.";
 
     public static final String MESSAGE_ADD_REMARK_SUCCESS = "Added remark to Elderly: %1$s";
+    public static final String MESSAGE_REMARK_NO_CHANGES = "Remark entered is the same as before";
     public static final String MESSAGE_DELETE_REMARK_SUCCESS = "Removed remark from Elderly: %1$s";
+    public static final String MESSAGE_REMARK_ALREADY_EMPTY = "No remark to be removed";
 
     private final Index index;
     private final Remark remark;
@@ -54,6 +56,15 @@ public class RemarkCommand extends Command {
         }
 
         Elderly elderlyToEdit = lastShownList.get(index.getZeroBased());
+
+        if (!elderlyToEdit.hasRemark() && remark.value.isEmpty()) {
+            throw new CommandException(MESSAGE_REMARK_ALREADY_EMPTY);
+        }
+
+        if (elderlyToEdit.getRemark().equals(remark)) {
+            throw new CommandException(MESSAGE_REMARK_NO_CHANGES);
+        }
+
         Elderly editedElderly = new Elderly(
                 elderlyToEdit.getName(), elderlyToEdit.getAge(), elderlyToEdit.getGender(),
                 elderlyToEdit.getRoomNumber(), elderlyToEdit.getNok(), remark, elderlyToEdit.getTags());

--- a/src/main/java/nurseybook/model/person/Elderly.java
+++ b/src/main/java/nurseybook/model/person/Elderly.java
@@ -141,4 +141,8 @@ public class Elderly extends Person {
         }
         return builder.toString();
     }
+
+    public boolean hasRemark() {
+        return !remark.value.isEmpty();
+    }
 }

--- a/src/test/java/nurseybook/logic/commands/RemarkCommandTest.java
+++ b/src/test/java/nurseybook/logic/commands/RemarkCommandTest.java
@@ -15,7 +15,6 @@ import static nurseybook.testutil.TypicalIndexes.INDEX_SECOND;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import nurseybook.testutil.ModelStub;
 import org.junit.jupiter.api.Test;
 
 import nurseybook.commons.core.index.Index;

--- a/src/test/java/nurseybook/model/person/ElderlyTest.java
+++ b/src/test/java/nurseybook/model/person/ElderlyTest.java
@@ -68,6 +68,15 @@ public class ElderlyTest {
     }
 
     @Test
+    public void hasRemark() {
+        Elderly aliceWithRemark = new ElderlyBuilder(ALICE).withRemark("Grouchy goat.").build();
+        assertTrue(aliceWithRemark.hasRemark());
+
+        Elderly bobNoRemark = new ElderlyBuilder(BOB).withRemark("").build();
+        assertFalse(bobNoRemark.hasRemark());
+    }
+
+    @Test
     public void equals() {
         // same values -> returns true
         Elderly aliceCopy = new ElderlyBuilder(ALICE).build();


### PR DESCRIPTION
Remark command allows
* the remark to be added to be the same as the specified elderly's current remark.
* deleting of an already empty remark

These commands are redundant.

Let's handle these situations by throwing appropriate CommandExceptions and feedback to the user accordingly.
