### PR TITLE
State requirements for adding an elderly in NurseyBook in User Guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -207,6 +207,7 @@ Format: `addElderly en/ELDERLY_NAME a/AGE g/GENDER r/ROOMNO [t/TAG]…​ [nn/NO
 
 :information_source: **Information:**
 * An elderly can have any number of tags (including 0).
+* NurseyBook does not support any two elderly with the same name, even if any other fields are different. A suggestion will be to save the full name of the elderly you are adding into NurseyBook.
 
 </div>
 


### PR DESCRIPTION
State clearly under the `addElderly` section that once an elderly with a specific `Name` is added, no other elderly with the exact same name is allowed to be added (despite different other particulars such as age, room number, gender etc.)

For example, if "Alex Yeoh" already exists in NurseyBook, no other "Alex Yeoh" can be added. However, "Alex Yeoh Ming" and "Alex Tan" are still accepted.

Fixes #122, #123, #135, #136. 