### PR TITLE
Change same elderly checks to be case insensitive when comparing names

### DIFF
--- a/src/main/java/nurseybook/logic/commands/AddTaskCommand.java
+++ b/src/main/java/nurseybook/logic/commands/AddTaskCommand.java
@@ -12,7 +12,6 @@ import static nurseybook.logic.parser.CliSyntax.PREFIX_TASK_TIME;
 
 import nurseybook.logic.commands.exceptions.CommandException;
 import nurseybook.model.Model;
-import nurseybook.model.person.Name;
 import nurseybook.model.task.Task;
 
 /**
@@ -59,15 +58,7 @@ public class AddTaskCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_TASK);
         }
 
-        boolean isElderlyPresent = true;
-        for (Name name : toAdd.getRelatedNames()) {
-            if (!model.isElderlyPresent(name)) {
-                isElderlyPresent = false;
-                break;
-            }
-        }
-
-        if (!isElderlyPresent) {
+        if (!model.areAllElderliesPresent(toAdd.getRelatedNames())) {
             throw new CommandException(MESSAGE_NO_SUCH_ELDERLY);
         }
 

--- a/src/main/java/nurseybook/logic/commands/EditTaskCommand.java
+++ b/src/main/java/nurseybook/logic/commands/EditTaskCommand.java
@@ -94,15 +94,8 @@ public class EditTaskCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_TASK);
         }
 
-        boolean isElderlyPresent = true;
-        for (Name name : editedTask.getRelatedNames()) {
-            if (!model.isElderlyPresent(name)) {
-                isElderlyPresent = false;
-                break;
-            }
-        }
 
-        if (!isElderlyPresent) {
+        if (!model.areAllElderliesPresent(editedTask.getRelatedNames())) {
             throw new CommandException(MESSAGE_NO_SUCH_ELDERLY);
         }
 

--- a/src/main/java/nurseybook/model/Model.java
+++ b/src/main/java/nurseybook/model/Model.java
@@ -2,6 +2,7 @@ package nurseybook.model;
 
 import java.nio.file.Path;
 import java.time.LocalDate;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -78,6 +79,7 @@ public interface Model {
     void markTaskAsDone(Task target);
 
     /**
+<<<<<<< Updated upstream
      * Marks the given task {@code target} as overdue.
      * {@code target} must exist in the nursey book.
      */
@@ -89,8 +91,11 @@ public interface Model {
      */
     void markTaskAsNotOverdue(Task target);
 
-
-    boolean isElderlyPresent(Name name);
+    /**
+     * Returns true if all the names in {@code names} are of some
+     * elderly present currently in NurseyBook.
+     */
+    boolean areAllElderliesPresent(Set<Name> names);
 
     void updateElderlyNameInTasks(Elderly target, Elderly editedElderly);
 

--- a/src/main/java/nurseybook/model/ModelManager.java
+++ b/src/main/java/nurseybook/model/ModelManager.java
@@ -5,6 +5,7 @@ import static nurseybook.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
 import java.time.LocalDate;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -127,13 +128,15 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean isElderlyPresent(Name name) {
-        for (Elderly elderly : filteredElderlies) {
-            if (elderly.getName().equals(name)) {
-                return true;
+    public boolean areAllElderliesPresent(Set<Name> names) {
+        for (Name name: names) {
+            boolean hasElderly = filteredElderlies.stream().anyMatch(
+                elderly -> elderly.getName().caseInsensitiveEquals(name));
+            if (!hasElderly) {
+                return false;
             }
         }
-        return false;
+        return true;
     }
 
     @Override
@@ -259,8 +262,8 @@ public class ModelManager implements Model {
         updateNotOverdueTaskList();
         updateDateRecurringTaskList();
         filteredTasks.setPredicate(predicate);
+        filteredTasks.setPredicate(predicate);
     }
-
     @Override
     public void updateOverdueTaskList() {
         Predicate<Task> predicate = new TaskIsOverduePredicate();
@@ -307,18 +310,15 @@ public class ModelManager implements Model {
         // state check
         ModelManager other = (ModelManager) obj;
 
-        if (elderlyOfInterest == null) {
-            return other.elderlyOfInterest == null
-                    && versionedNurseyBook.equals(other.versionedNurseyBook)
-                    && userPrefs.equals(other.userPrefs)
-                    && filteredElderlies.equals(other.filteredElderlies)
-                    && filteredTasks.equals(other.filteredTasks);
-        }
-        return other.elderlyOfInterest != null
+        boolean areElderlyOfInterestsEqual = elderlyOfInterest == null && other.elderlyOfInterest == null
+                ? true
+                : elderlyOfInterest == null || other.elderlyOfInterest == null
+                    ? false
+                    : elderlyOfInterest.equals(other.elderlyOfInterest);
+        return areElderlyOfInterestsEqual
                 && versionedNurseyBook.equals(other.versionedNurseyBook)
                 && userPrefs.equals(other.userPrefs)
                 && filteredElderlies.equals(other.filteredElderlies)
-                && elderlyOfInterest.equals(other.elderlyOfInterest)
                 && filteredTasks.equals(other.filteredTasks);
     }
 

--- a/src/main/java/nurseybook/model/ModelManager.java
+++ b/src/main/java/nurseybook/model/ModelManager.java
@@ -262,7 +262,6 @@ public class ModelManager implements Model {
         updateNotOverdueTaskList();
         updateDateRecurringTaskList();
         filteredTasks.setPredicate(predicate);
-        filteredTasks.setPredicate(predicate);
     }
     @Override
     public void updateOverdueTaskList() {
@@ -310,11 +309,9 @@ public class ModelManager implements Model {
         // state check
         ModelManager other = (ModelManager) obj;
 
-        boolean areElderlyOfInterestsEqual = elderlyOfInterest == null && other.elderlyOfInterest == null
-                ? true
-                : elderlyOfInterest == null || other.elderlyOfInterest == null
-                    ? false
-                    : elderlyOfInterest.equals(other.elderlyOfInterest);
+        boolean areElderlyOfInterestsEqual = elderlyOfInterest == null
+                ? other.elderlyOfInterest == null
+                : elderlyOfInterest.equals(other.elderlyOfInterest);
         return areElderlyOfInterestsEqual
                 && versionedNurseyBook.equals(other.versionedNurseyBook)
                 && userPrefs.equals(other.userPrefs)

--- a/src/main/java/nurseybook/model/person/Elderly.java
+++ b/src/main/java/nurseybook/model/person/Elderly.java
@@ -82,7 +82,7 @@ public class Elderly extends Person {
         }
 
         return otherElderly != null
-                && otherElderly.getName().equals(getName());
+                && this.getName().caseInsensitiveEquals(otherElderly.getName());
     }
 
     /**

--- a/src/main/java/nurseybook/model/person/Elderly.java
+++ b/src/main/java/nurseybook/model/person/Elderly.java
@@ -89,7 +89,7 @@ public class Elderly extends Person {
      * Returns true if elderly has this name.
      */
     public boolean hasName(Name name) {
-        return this.getName().equals(name);
+        return this.getName().caseInsensitiveEquals(name);
     }
 
     /**

--- a/src/main/java/nurseybook/model/person/Name.java
+++ b/src/main/java/nurseybook/model/person/Name.java
@@ -38,6 +38,9 @@ public class Name {
         return test.matches(VALIDATION_REGEX);
     }
 
+    public boolean caseInsensitiveEquals(Name other) {
+        return fullName.equalsIgnoreCase(other.fullName); // state check
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/nurseybook/model/task/UniqueTaskList.java
+++ b/src/main/java/nurseybook/model/task/UniqueTaskList.java
@@ -130,7 +130,7 @@ public class UniqueTaskList implements Iterable<Task> {
     public void updateElderlyNameInTasks(Elderly target, Elderly editedElderly) {
         for (Task task : internalList) {
             for (Name name : task.getRelatedNames()) {
-                if (target.getName().equals(name)) {
+                if (target.getName().caseInsensitiveEquals(name)) {
                     task.replaceName(name, editedElderly.getName());
                 }
             }
@@ -145,7 +145,7 @@ public class UniqueTaskList implements Iterable<Task> {
     public void deleteElderlyNameInTasks(Elderly elderlyToDelete) {
         for (Task task : internalList) {
             for (Name name : task.getRelatedNames()) {
-                if (elderlyToDelete.getName().equals(name)) {
+                if (elderlyToDelete.getName().caseInsensitiveEquals(name)) {
                     task.deleteName(name);
                 }
             }

--- a/src/test/java/nurseybook/logic/commands/AddCommandTest.java
+++ b/src/test/java/nurseybook/logic/commands/AddCommandTest.java
@@ -51,6 +51,16 @@ public class AddCommandTest {
     }
 
     @Test
+    public void execute_duplicateElderlyCaseInsensitive_throwsCommandException() {
+        Elderly randomCaseAlice = new ElderlyBuilder().withName("alICe").build();
+        Elderly existingAlice = new ElderlyBuilder().withName("Alice").build();
+        AddCommand addCommand = new AddCommand(randomCaseAlice);
+        ModelStub modelStub = new ModelStubWithElderly(existingAlice);
+
+        assertThrows(CommandException.class, MESSAGE_DUPLICATE_ELDERLY, () -> addCommand.execute(modelStub));
+    }
+
+    @Test
     public void equals() {
         Elderly alice = new ElderlyBuilder().withName("Alice").build();
         Elderly bob = new ElderlyBuilder().withName("Bob").build();

--- a/src/test/java/nurseybook/logic/commands/AddTaskCommandIntegrationTest.java
+++ b/src/test/java/nurseybook/logic/commands/AddTaskCommandIntegrationTest.java
@@ -1,0 +1,51 @@
+package nurseybook.logic.commands;
+
+import static nurseybook.commons.core.Messages.MESSAGE_NO_SUCH_ELDERLY;
+import static nurseybook.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static nurseybook.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import nurseybook.logic.commands.exceptions.CommandException;
+import nurseybook.model.Model;
+import nurseybook.model.ModelManager;
+import nurseybook.model.person.Elderly;
+import nurseybook.model.task.Task;
+import nurseybook.testutil.ElderlyBuilder;
+import nurseybook.testutil.TaskBuilder;
+
+public class AddTaskCommandIntegrationTest {
+
+    @Test
+    public void execute_elderliesInNurseyBook_success() {
+        Model model = new ModelManager();
+        Task validTask = new TaskBuilder().withNames("Alex Yeoh", "George Tan").build();
+        Elderly firstElderly = new ElderlyBuilder().withName("Alex Yeoh").build();
+        Elderly secondElderly = new ElderlyBuilder().withName("george taN").build();
+
+        model.addElderly(firstElderly);
+        model.addElderly(secondElderly);
+
+
+        AddTaskCommand addTaskCommand = new AddTaskCommand(validTask);
+
+        CommandResult expectedResult = new CommandResult(String.format(AddTaskCommand.MESSAGE_SUCCESS, validTask),
+                CommandResult.ListDisplayChange.TASK);
+        Model expectedModel = new ModelManager();
+        expectedModel.addElderly(firstElderly);
+        expectedModel.addElderly(secondElderly);
+        expectedModel.addTask(validTask);
+        expectedModel.commitNurseyBook(expectedResult);
+
+        assertCommandSuccess(addTaskCommand, model, expectedResult, expectedModel);
+    }
+
+    @Test
+    public void execute_elderlyNotInNurseyBook_throwsCommandException() {
+        Model model = new ModelManager();
+        Task validTask = new TaskBuilder().withNames("Alex Yeoh").build();
+        AddTaskCommand addTaskCommand = new AddTaskCommand(validTask);
+        assertThrows(CommandException.class, MESSAGE_NO_SUCH_ELDERLY, () -> addTaskCommand.execute(model));
+    }
+
+}

--- a/src/test/java/nurseybook/logic/commands/AddTaskCommandTest.java
+++ b/src/test/java/nurseybook/logic/commands/AddTaskCommandTest.java
@@ -2,7 +2,6 @@ package nurseybook.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static nurseybook.commons.core.Messages.MESSAGE_DUPLICATE_TASK;
-import static nurseybook.commons.core.Messages.MESSAGE_NO_SUCH_ELDERLY;
 import static nurseybook.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -10,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,11 +17,16 @@ import nurseybook.logic.commands.exceptions.CommandException;
 import nurseybook.model.NurseyBook;
 import nurseybook.model.ReadOnlyNurseyBook;
 import nurseybook.model.VersionedNurseyBook;
+import nurseybook.model.person.Name;
 import nurseybook.model.task.Task;
 import nurseybook.testutil.ModelStub;
 import nurseybook.testutil.NurseyBookBuilder;
 import nurseybook.testutil.TaskBuilder;
 
+/**
+ * Testing AddTaskCommand's task aspect only, isolating it from elderly in this test class.
+ * Thus, all tasks tested should be without elderly names.
+ */
 public class AddTaskCommandTest {
     @Test
     public void constructor_nullTask_throwsNullPointerException() {
@@ -34,10 +39,10 @@ public class AddTaskCommandTest {
         Task validTask = new TaskBuilder().build();
 
         CommandResult commandResult = new AddTaskCommand(validTask).execute(modelStub);
-        CommandResult expectedCommand = new CommandResult(String.format(AddTaskCommand.MESSAGE_SUCCESS, validTask),
+        CommandResult expectedResult = new CommandResult(String.format(AddTaskCommand.MESSAGE_SUCCESS, validTask),
                 CommandResult.ListDisplayChange.TASK);
 
-        assertEquals(expectedCommand, commandResult);
+        assertEquals(expectedResult, commandResult);
         assertEquals(Arrays.asList(validTask), modelStub.tasksAdded);
     }
 
@@ -49,13 +54,6 @@ public class AddTaskCommandTest {
         assertThrows(CommandException.class, MESSAGE_DUPLICATE_TASK, () -> addTaskCommand.execute(modelStub));
     }
 
-    @Test
-    public void execute_elderlyNotInNurseyBook_throwsCommandException() {
-        ModelStubAcceptingTaskAdded modelStub = new ModelStubAcceptingTaskAdded();
-        Task validTask = new TaskBuilder().withNames("Alex Yeoh").build();
-        AddTaskCommand addTaskCommand = new AddTaskCommand(validTask);
-        assertThrows(CommandException.class, MESSAGE_NO_SUCH_ELDERLY, () -> addTaskCommand.execute(modelStub));
-    }
 
     @Test
     public void equals() {
@@ -116,6 +114,11 @@ public class AddTaskCommandTest {
         public void addTask(Task t) {
             requireNonNull(t);
             tasksAdded.add(t);
+        }
+
+        @Override
+        public boolean areAllElderliesPresent(Set<Name> names) {
+            return true;
         }
 
         @Override

--- a/src/test/java/nurseybook/logic/commands/EditCommandTest.java
+++ b/src/test/java/nurseybook/logic/commands/EditCommandTest.java
@@ -14,6 +14,7 @@ import static nurseybook.logic.commands.CommandTestUtil.assertCommandFailure;
 import static nurseybook.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static nurseybook.logic.commands.CommandTestUtil.showElderlyAtIndex;
 import static nurseybook.logic.commands.EditCommand.MESSAGE_EDIT_ELDERLY_SUCCESS;
+import static nurseybook.logic.commands.TaskCommandTestUtil.VALID_NAME_ALICE;
 import static nurseybook.logic.commands.TaskCommandTestUtil.showTaskAtIndex;
 import static nurseybook.testutil.TypicalElderlies.getTypicalNurseyBook;
 import static nurseybook.testutil.TypicalIndexes.INDEX_FIRST;
@@ -98,6 +99,24 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_editElderlyNameCaseChange_success() {
+        showElderlyAtIndex(model, INDEX_FIRST);
+
+        Elderly elderlyInFilteredList = model.getFilteredElderlyList().get(INDEX_FIRST.getZeroBased());
+        Elderly editedElderly = new ElderlyBuilder(elderlyInFilteredList)
+                .withName(VALID_NAME_ALICE.toLowerCase()).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST,
+                new EditElderlyDescriptorBuilder().withName(VALID_NAME_ALICE.toLowerCase()).build());
+        String expectedMessage = String.format(MESSAGE_EDIT_ELDERLY_SUCCESS, editedElderly);
+
+        Model expectedModel = new ModelManager(new NurseyBook(model.getVersionedNurseyBook()), new UserPrefs());
+        expectedModel.setElderly(model.getFilteredElderlyList().get(INDEX_FIRST.getZeroBased()), editedElderly);
+        expectedModel.commitNurseyBook(new CommandResult(expectedMessage));
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
     public void execute_editAllInstancesOfElderlyWithNameInTasks_success() throws CommandException {
         showElderlyAtIndex(model, INDEX_FIRST);
         model.addTask(ALICE_INSULIN);
@@ -113,9 +132,17 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicateElderlyUnfilteredList_failure() {
+        //name case all the same
         Elderly firstElderly = model.getFilteredElderlyList().get(INDEX_FIRST.getZeroBased());
         EditCommand.EditElderlyDescriptor descriptor = new EditElderlyDescriptorBuilder(firstElderly).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND, descriptor);
+
+        assertCommandFailure(editCommand, model, MESSAGE_DUPLICATE_ELDERLY);
+
+        //name case different
+        descriptor = new EditElderlyDescriptorBuilder(firstElderly)
+                .withName("alIcE pauline").build(); //first elderly is Alice Pauline
+        editCommand = new EditCommand(INDEX_SECOND, descriptor);
 
         assertCommandFailure(editCommand, model, MESSAGE_DUPLICATE_ELDERLY);
     }
@@ -126,6 +153,11 @@ public class EditCommandTest {
         Elderly elderlyInList = model.getFilteredElderlyList().get(INDEX_SECOND.getZeroBased());
         EditCommand editCommand = new EditCommand(INDEX_FIRST,
                 new EditElderlyDescriptorBuilder(elderlyInList).build());
+        assertCommandFailure(editCommand, model, MESSAGE_DUPLICATE_ELDERLY);
+
+        // still editing into duplicate but name casing is different
+        editCommand = new EditCommand(INDEX_FIRST,
+                new EditElderlyDescriptorBuilder(elderlyInList).withName("benson meier").build());
         assertCommandFailure(editCommand, model, MESSAGE_DUPLICATE_ELDERLY);
     }
 

--- a/src/test/java/nurseybook/model/person/ElderlyTest.java
+++ b/src/test/java/nurseybook/model/person/ElderlyTest.java
@@ -44,13 +44,13 @@ public class ElderlyTest {
                 .withTags(VALID_TAG_HUSBAND).build();
         assertTrue(ALICE.isSameElderly(editedAlice));
 
+        // name differs in case, all other attributes same -> returns true
+        Elderly editedBob = new ElderlyBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
+        assertTrue(BOB.isSameElderly(editedBob));
+
         // different name, all other attributes same -> returns false
         editedAlice = new ElderlyBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSameElderly(editedAlice));
-
-        // name differs in case, all other attributes same -> returns false
-        Elderly editedBob = new ElderlyBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSameElderly(editedBob));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";

--- a/src/test/java/nurseybook/model/person/NameTest.java
+++ b/src/test/java/nurseybook/model/person/NameTest.java
@@ -36,4 +36,16 @@ public class NameTest {
         assertTrue(Name.isValidName("peter jack")); // alphabets only
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
     }
+
+    @Test
+    public void caseInsensitiveEquals() {
+        Name testName = new Name("Hubert");
+
+        //different names
+        assertFalse(testName.caseInsensitiveEquals(new Name("george")));
+
+        //same name diff case
+        assertTrue(testName.caseInsensitiveEquals(new Name("hUbeRT")));
+
+    }
 }

--- a/src/test/java/nurseybook/testutil/ModelStub.java
+++ b/src/test/java/nurseybook/testutil/ModelStub.java
@@ -2,6 +2,7 @@ package nurseybook.testutil;
 
 import java.nio.file.Path;
 import java.time.LocalDate;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -105,11 +106,6 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public boolean isElderlyPresent(Name name) {
-        return false;
-    }
-
-    @Override
     public void updateElderlyNameInTasks(Elderly target, Elderly editedElderly) {
         throw new AssertionError("This method should not be called.");
     }
@@ -136,6 +132,11 @@ public class ModelStub implements Model {
 
     @Override
     public void markTaskAsNotOverdue(Task target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean areAllElderliesPresent(Set<Name> names) {
         throw new AssertionError("This method should not be called.");
     }
 


### PR DESCRIPTION
Currently, 
* `addElderly` and `editElderly` allows elderlies Jessica Lee and jessica lee to be in NurseyBook simultaneously.
* `addTask` and `editTask` throw errors when Jessica Lee is present in NurseyBook but the elderly name entered is 'jessica lee'.

Let's introduce case-insensitive name checking.