### PR TITLE
Fix bug when trying to undo deleting elderly whose name is in the task

### DIFF
--- a/src/main/java/nurseybook/model/task/Task.java
+++ b/src/main/java/nurseybook/model/task/Task.java
@@ -16,7 +16,7 @@ public abstract class Task implements Comparable<Task> {
     private final Description desc;
     private DateTime dateTime;
     private final Status status;
-    private final Set<Name> relatedNames = new HashSet<>();
+    private Set<Name> relatedNames = new HashSet<>();
     private final Recurrence recurrence;
 
     /**
@@ -154,18 +154,24 @@ public abstract class Task implements Comparable<Task> {
     }
 
     /**
-     * Replaces the name {@code target} of the task with {@code editedName}.
+     * Returns a copy of the task with the name {@code target} replaced with {@code editedName}
+     * in {@code relatedNames} of the task.
      */
-    public void replaceName(Name target, Name editedName) {
-        deleteName(target);
-        addName(editedName);
+    public Task replaceName(Name target, Name editedName) {
+        Task updatedTask = deleteName(target);
+        updatedTask.addName(editedName);
+        return updatedTask;
     }
 
     /**
-     * Deletes the name {@code target} of the task.
+     * Returns a copy of the task with the name {@code target} deleted from {@code relatedNames} of the task.
      */
-    public void deleteName(Name target) {
-        relatedNames.remove(target);
+    public Task deleteName(Name target) {
+        Set<Name> updatedNames = new HashSet<>(relatedNames);
+        updatedNames.remove(target);
+        Task updatedTask = copyTask();
+        updatedTask.setRelatedNames(updatedNames);
+        return updatedTask;
     }
 
     /**
@@ -229,6 +235,14 @@ public abstract class Task implements Comparable<Task> {
         this.dateTime = new DateTime(newDate, this.dateTime.getTime());
     }
 
+    /**
+     * Changes the related names of the task to the intended set of names
+     *
+     * @param newNames The intended set of names
+     */
+    public void setRelatedNames(Set<Name> newNames) {
+        this.relatedNames = newNames;
+    }
     /**
      * Copies the task and all it's fields and returns a new instance of it.
      *

--- a/src/main/java/nurseybook/model/task/UniqueTaskList.java
+++ b/src/main/java/nurseybook/model/task/UniqueTaskList.java
@@ -126,7 +126,8 @@ public class UniqueTaskList implements Iterable<Task> {
         for (Task task : internalList) {
             for (Name name : task.getRelatedNames()) {
                 if (target.getName().caseInsensitiveEquals(name)) {
-                    task.replaceName(name, editedElderly.getName());
+                    internalList.remove(task);
+                    internalList.add(task.replaceName(name, editedElderly.getName()));
                 }
             }
         }
@@ -141,7 +142,8 @@ public class UniqueTaskList implements Iterable<Task> {
         for (Task task : internalList) {
             for (Name name : task.getRelatedNames()) {
                 if (elderlyToDelete.getName().caseInsensitiveEquals(name)) {
-                    task.deleteName(name);
+                    internalList.remove(task);
+                    internalList.add(task.deleteName(name));
                 }
             }
         }


### PR DESCRIPTION
Edits to the related names list are done on a copy of the task so that the versioned nursey book can store a copy of the previous task.

Fixes the missing elderly name in task after undoing deleteElderly command.