### PR TITLE
Fix issue where modifying storage causes task/elderly inconsistency

### DIFF
--- a/src/main/java/nurseybook/model/Model.java
+++ b/src/main/java/nurseybook/model/Model.java
@@ -88,7 +88,7 @@ public interface Model {
      * Returns first and only elderly in NurseyBook whose name matches {@code name} (case-insensitive matching).
      * Since only one elderly in NurseyBook is allowed to have a particular name, this returns only one elderly.
      */
-    public Elderly findElderlyWithName(Name name);
+    Elderly findElderlyWithName(Name name);
 
     void updateElderlyNameInTasks(Elderly target, Elderly editedElderly);
 

--- a/src/main/java/nurseybook/model/ModelManager.java
+++ b/src/main/java/nurseybook/model/ModelManager.java
@@ -116,22 +116,12 @@ public class ModelManager implements Model {
 
     @Override
     public boolean areAllElderliesPresent(Set<Name> names) {
-        for (Name name: names) {
-            boolean hasElderly = filteredElderlies.stream().anyMatch(
-                elderly -> elderly.getName().caseInsensitiveEquals(name));
-            if (!hasElderly) {
-                return false;
-            }
-        }
-        return true;
+        return versionedNurseyBook.areAllElderliesPresent(names);
     }
 
     @Override
     public Elderly findElderlyWithName(Name name) {
-        return filteredElderlies.stream()
-                .filter(elderly -> elderly.getName().caseInsensitiveEquals(name))
-                .findFirst()
-                .orElse(null);
+        return versionedNurseyBook.findElderlyWithName(name);
     }
 
     @Override

--- a/src/main/java/nurseybook/model/NurseyBook.java
+++ b/src/main/java/nurseybook/model/NurseyBook.java
@@ -245,7 +245,7 @@ public class NurseyBook implements ReadOnlyNurseyBook {
 
     @Override
     public boolean doTasksContainValidNames() {
-        return tasks.doTasksContainValidNames(elderlies.asUnmodifiableObservableList());
+        return tasks.doTasksContainValidNames(elderlies);
     }
 
     /**

--- a/src/main/java/nurseybook/model/NurseyBook.java
+++ b/src/main/java/nurseybook/model/NurseyBook.java
@@ -82,11 +82,6 @@ public class NurseyBook implements ReadOnlyNurseyBook {
         return elderlies.contains(elderly);
     }
 
-    public Elderly getElderly(Name name) {
-        requireNonNull(name);
-        return elderlies.getElderly(name);
-    }
-
     /**
      * Adds a elderly to NurseyBook.
      * The elderly must not already exist in NurseyBook.
@@ -266,11 +261,8 @@ public class NurseyBook implements ReadOnlyNurseyBook {
      * elderly present currently in NurseyBook.
      */
     public boolean areAllElderliesPresent(Set<Name> names) {
-        ObservableList<Elderly> unmodifiableElderlies = elderlies.asUnmodifiableObservableList();
         for (Name name: names) {
-            boolean hasElderly = unmodifiableElderlies.stream().anyMatch(
-                elderly -> elderly.getName().caseInsensitiveEquals(name));
-            if (!hasElderly) {
+            if (!elderlies.hasElderly(name)) {
                 return false;
             }
         }
@@ -282,10 +274,6 @@ public class NurseyBook implements ReadOnlyNurseyBook {
      * Since only one elderly in NurseyBook is allowed to have a particular name, this returns only one elderly.
      */
     public Elderly findElderlyWithName(Name name) {
-        return elderlies.asUnmodifiableObservableList()
-                .stream()
-                .filter(elderly -> elderly.getName().caseInsensitiveEquals(name))
-                .findFirst()
-                .orElse(null);
+        return elderlies.getElderly(name);
     }
 }

--- a/src/main/java/nurseybook/model/NurseyBook.java
+++ b/src/main/java/nurseybook/model/NurseyBook.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import javafx.collections.ObservableList;
 import nurseybook.model.person.Elderly;
@@ -247,6 +248,11 @@ public class NurseyBook implements ReadOnlyNurseyBook {
         return realTaskList.asUnmodifiableObservableList();
     }
 
+    @Override
+    public boolean doTasksContainValidNames() {
+        return tasks.doTasksContainValidNames(elderlies.asUnmodifiableObservableList());
+    }
+
     /**
      * Marks the given task {@code target} as done.
      * {@code target} must exist in NurseyBook.
@@ -255,4 +261,31 @@ public class NurseyBook implements ReadOnlyNurseyBook {
         tasks.markTaskAsDone(target);
     }
 
+    /**
+     * Returns true if all the names in {@code names} are of some
+     * elderly present currently in NurseyBook.
+     */
+    public boolean areAllElderliesPresent(Set<Name> names) {
+        ObservableList<Elderly> unmodifiableElderlies = elderlies.asUnmodifiableObservableList();
+        for (Name name: names) {
+            boolean hasElderly = unmodifiableElderlies.stream().anyMatch(
+                elderly -> elderly.getName().caseInsensitiveEquals(name));
+            if (!hasElderly) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns first and only elderly in NurseyBook whose name matches {@code name} (case-insensitive matching).
+     * Since only one elderly in NurseyBook is allowed to have a particular name, this returns only one elderly.
+     */
+    public Elderly findElderlyWithName(Name name) {
+        return elderlies.asUnmodifiableObservableList()
+                .stream()
+                .filter(elderly -> elderly.getName().caseInsensitiveEquals(name))
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/src/main/java/nurseybook/model/ReadOnlyNurseyBook.java
+++ b/src/main/java/nurseybook/model/ReadOnlyNurseyBook.java
@@ -25,4 +25,8 @@ public interface ReadOnlyNurseyBook {
      */
     ObservableList<Task> getRealTaskList();
 
+    /**
+     * Returns true if all tasks contain only names of existing elderly in NurseyBook.
+     */
+    boolean doTasksContainValidNames();
 }

--- a/src/main/java/nurseybook/model/person/UniqueElderlyList.java
+++ b/src/main/java/nurseybook/model/person/UniqueElderlyList.java
@@ -54,6 +54,16 @@ public class UniqueElderlyList implements Iterable<Elderly> {
     }
 
     /**
+     * Returns elderly with {@code name}
+     * Elderly with {@code name} must exist in list.
+     */
+    public boolean hasElderly(Name name) {
+        requireNonNull(name);
+        return internalList.stream()
+                .anyMatch(p -> p.hasName(name));
+    }
+
+    /**
      * Adds a elderly to the list.
      * The elderly must not already exist in the list.
      */

--- a/src/main/java/nurseybook/model/task/Task.java
+++ b/src/main/java/nurseybook/model/task/Task.java
@@ -8,6 +8,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import javafx.collections.ObservableList;
+import nurseybook.model.person.Elderly;
 import nurseybook.model.person.Name;
 import nurseybook.model.task.Recurrence.RecurrenceType;
 
@@ -322,6 +324,19 @@ public abstract class Task implements Comparable<Task> {
         return otherTask != null
                 && otherTask.getDesc().equals(getDesc()) && otherTask.getDateTime().equals(getDateTime())
                 && otherTask.getRelatedNames().equals(getRelatedNames());
+    }
+
+    /**
+     * Returns true if related names are all of existing elderlies in NurseyBook.
+     */
+    public boolean isRelatedNamesValid(ObservableList<Elderly> elderlies) {
+        for (Name name : relatedNames) {
+            boolean hasElderly = elderlies.stream().anyMatch(elderly -> elderly.getName().caseInsensitiveEquals(name));
+            if (!hasElderly) {
+                return false;
+            }
+        }
+        return true;
     }
 
     //@@ Superbestron

--- a/src/main/java/nurseybook/model/task/Task.java
+++ b/src/main/java/nurseybook/model/task/Task.java
@@ -8,9 +8,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import javafx.collections.ObservableList;
-import nurseybook.model.person.Elderly;
 import nurseybook.model.person.Name;
+import nurseybook.model.person.UniqueElderlyList;
 import nurseybook.model.task.Recurrence.RecurrenceType;
 
 public abstract class Task implements Comparable<Task> {
@@ -329,14 +328,8 @@ public abstract class Task implements Comparable<Task> {
     /**
      * Returns true if related names are all of existing elderlies in NurseyBook.
      */
-    public boolean isRelatedNamesValid(ObservableList<Elderly> elderlies) {
-        for (Name name : relatedNames) {
-            boolean hasElderly = elderlies.stream().anyMatch(elderly -> elderly.getName().caseInsensitiveEquals(name));
-            if (!hasElderly) {
-                return false;
-            }
-        }
-        return true;
+    public boolean isRelatedNamesValid(UniqueElderlyList elderlies) {
+        return relatedNames.stream().allMatch(name -> elderlies.hasElderly(name));
     }
 
     //@@ Superbestron

--- a/src/main/java/nurseybook/model/task/UniqueTaskList.java
+++ b/src/main/java/nurseybook/model/task/UniqueTaskList.java
@@ -122,6 +122,21 @@ public class UniqueTaskList implements Iterable<Task> {
      * {@code target} must exist in NurseyBook.
      * The elderly identity of {@code editedElderly} must not be the same as another existing elderly in NurseyBook.
      */
+    public boolean doTasksContainValidNames(ObservableList<Elderly> elderlies) {
+        for (Task t: internalList) {
+            if (!t.isRelatedNamesValid(elderlies)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Updates the given elderly {@code target}'s name for all tasks in the list that contains that name
+     * with {@code editedElderly}'s name.
+     * {@code target} must exist in NurseyBook.
+     * The elderly identity of {@code editedElderly} must not be the same as another existing elderly in NurseyBook.
+     */
     public void updateElderlyNameInTasks(Elderly target, Elderly editedElderly) {
         for (Task task : internalList) {
             for (Name name : task.getRelatedNames()) {

--- a/src/main/java/nurseybook/model/task/UniqueTaskList.java
+++ b/src/main/java/nurseybook/model/task/UniqueTaskList.java
@@ -14,6 +14,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import nurseybook.model.person.Elderly;
 import nurseybook.model.person.Name;
+import nurseybook.model.person.UniqueElderlyList;
 import nurseybook.model.task.exceptions.DuplicateTaskException;
 import nurseybook.model.task.exceptions.TaskNotFoundException;
 
@@ -122,7 +123,7 @@ public class UniqueTaskList implements Iterable<Task> {
      * {@code target} must exist in NurseyBook.
      * The elderly identity of {@code editedElderly} must not be the same as another existing elderly in NurseyBook.
      */
-    public boolean doTasksContainValidNames(ObservableList<Elderly> elderlies) {
+    public boolean doTasksContainValidNames(UniqueElderlyList elderlies) {
         for (Task t: internalList) {
             if (!t.isRelatedNamesValid(elderlies)) {
                 return false;

--- a/src/main/java/nurseybook/storage/JsonNurseyBookStorage.java
+++ b/src/main/java/nurseybook/storage/JsonNurseyBookStorage.java
@@ -21,6 +21,8 @@ public class JsonNurseyBookStorage implements NurseyBookStorage {
 
     private static final Logger logger = LogsCenter.getLogger(JsonNurseyBookStorage.class);
 
+    private static final String INVALID_NAMES_IN_TASKS = "Tasks contain invalid elderly names";
+
     private Path filePath;
 
     public JsonNurseyBookStorage(Path filePath) {
@@ -30,6 +32,7 @@ public class JsonNurseyBookStorage implements NurseyBookStorage {
     public Path getNurseyBookFilePath() {
         return filePath;
     }
+
 
     @Override
     public Optional<ReadOnlyNurseyBook> readNurseyBook() throws DataConversionException {
@@ -52,7 +55,12 @@ public class JsonNurseyBookStorage implements NurseyBookStorage {
         }
 
         try {
-            return Optional.of(jsonNurseyBook.get().toModelType());
+            Optional<ReadOnlyNurseyBook> nb = Optional.of(jsonNurseyBook.get().toModelType());
+            if (nb.isPresent() && !nb.get().doTasksContainValidNames()) {
+                logger.info("Illegal values found in " + filePath + ": " + INVALID_NAMES_IN_TASKS);
+                throw new DataConversionException(new IllegalValueException(INVALID_NAMES_IN_TASKS));
+            }
+            return nb;
         } catch (IllegalValueException ive) {
             logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
             throw new DataConversionException(ive);

--- a/src/test/data/JsonNurseyBookStorageTest/tasksWithInvalidElderlyNurseyBook.json
+++ b/src/test/data/JsonNurseyBookStorageTest/tasksWithInvalidElderlyNurseyBook.json
@@ -1,0 +1,31 @@
+{
+  "elderlies": [ {
+    "name": "Valid Elderly",
+    "age": "40",
+    "gender": "M",
+    "roomNumber": "52",
+    "nokName": "Valid Nok",
+    "relationship": "Mother",
+    "phone": "9482424",
+    "email": "hans@example.com",
+    "address": "4th street"
+  }, {
+    "name": "Jeffrey",
+    "age": "40",
+    "gender": "M",
+    "roomNumber": "52",
+    "nokName": "Valid Nok",
+    "relationship": "Mother",
+    "phone": "948asdf2424",
+    "email": "hans@example.com",
+    "address": "4th street"
+  } ],
+  "tasks": [ {
+    "names" : [ "Bernard" ],
+    "description" : "i duno",
+    "date" : "2021-12-04",
+    "time" : "10:00:00",
+    "status" : [ "false", "false" ],
+    "recurrence" : "NONE"
+  } ]
+}

--- a/src/test/java/nurseybook/model/ModelManagerTest.java
+++ b/src/test/java/nurseybook/model/ModelManagerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import nurseybook.commons.core.GuiSettings;
 import nurseybook.model.person.Name;
 import nurseybook.model.person.NameContainsKeywordsPredicate;
+import nurseybook.model.person.exceptions.ElderlyNotFoundException;
 import nurseybook.testutil.NurseyBookBuilder;
 
 public class ModelManagerTest {
@@ -144,7 +145,7 @@ public class ModelManagerTest {
     public void findElderlyWithName_differentName_returnsNull() {
         //name is does not match any elderly
         modelManager = new ModelManager();
-        assertTrue(modelManager.findElderlyWithName(new Name("george")) == null);
+        assertThrows(ElderlyNotFoundException.class, () -> modelManager.findElderlyWithName(new Name("george")));
     }
 
     @Test

--- a/src/test/java/nurseybook/model/NurseyBookTest.java
+++ b/src/test/java/nurseybook/model/NurseyBookTest.java
@@ -132,6 +132,11 @@ public class NurseyBookTest {
             return tasks;
         }
 
+        @Override
+        public boolean doTasksContainValidNames() {
+            return true;
+        }
+
     }
 
 }

--- a/src/test/java/nurseybook/storage/JsonNurseyBookStorageTest.java
+++ b/src/test/java/nurseybook/storage/JsonNurseyBookStorageTest.java
@@ -64,6 +64,12 @@ public class JsonNurseyBookStorageTest {
     }
 
     @Test
+    public void readNurseyBook_tasksWithInvalidElderlyNurseyBook_throwDataConversionException() {
+        assertThrows(DataConversionException.class, () -> readNurseyBook(
+                "tasksWithInvalidElderlyNurseyBook.json"));
+    }
+
+    @Test
     public void readAndSavePeopleInNurseyBook_allInOrder_success() throws Exception {
         Path filePath = testFolder.resolve("TempNurseyBook.json");
         NurseyBook original = TypicalElderlies.getTypicalNurseyBook();


### PR DESCRIPTION
Additionally, there's a bug in my previous implementation where tasks were only searching for existing elderly in the filtered list. In the scenario where findElderly/ filter was executed, entering a valid elderly name would result in an error.

Let's also fix the above mentioned issue.