### PR TITLE
Fix bug where editing .json file can result in duplicate elderly names

### DIFF
--- a/src/main/java/nurseybook/model/person/Elderly.java
+++ b/src/main/java/nurseybook/model/person/Elderly.java
@@ -86,10 +86,17 @@ public class Elderly extends Person {
     }
 
     /**
-     * Returns true if elderly has this name.
+     * Returns true if elderly has this name (case-insensitive).
      */
     public boolean hasName(Name name) {
         return this.getName().caseInsensitiveEquals(name);
+    }
+
+    /**
+     * Returns true if elderly has this name (case-sensitive).
+     */
+    public boolean hasNameCaseSensitive(Name name) {
+        return this.getName().equals(name);
     }
 
     /**

--- a/src/main/java/nurseybook/model/person/UniqueElderlyList.java
+++ b/src/main/java/nurseybook/model/person/UniqueElderlyList.java
@@ -64,6 +64,16 @@ public class UniqueElderlyList implements Iterable<Elderly> {
     }
 
     /**
+     * Case-sensitive version of
+     * @see UniqueElderlyList#hasElderly(Name)
+     */
+    public boolean hasElderlyCaseSensitive(Name name) {
+        requireNonNull(name);
+        return internalList.stream()
+                .anyMatch(p -> p.hasNameCaseSensitive(name));
+    }
+
+    /**
      * Adds a elderly to the list.
      * The elderly must not already exist in the list.
      */

--- a/src/main/java/nurseybook/model/task/Task.java
+++ b/src/main/java/nurseybook/model/task/Task.java
@@ -326,10 +326,11 @@ public abstract class Task implements Comparable<Task> {
     }
 
     /**
-     * Returns true if related names are all of existing elderlies in NurseyBook.
+     * Returns true if related names are all of existing elderlies in NurseyBook and each name has the same case as the
+     * corresponding elderly's name.
      */
     public boolean isRelatedNamesValid(UniqueElderlyList elderlies) {
-        return relatedNames.stream().allMatch(name -> elderlies.hasElderly(name));
+        return relatedNames.stream().allMatch(name -> elderlies.hasElderlyCaseSensitive(name));
     }
 
     //@@ Superbestron


### PR DESCRIPTION
Currently, if a user entered "kanye" and "KANYE" in the nurseybook.json, the task will have both names. Let's change it such that the elderly name in tasks must equal the corresponding elderly name (casing included) when reading the .json file. Else, error is thrown upon reading from storage and NurseyBook will be set to empty.